### PR TITLE
Hide y axis scroll bar from cache loader

### DIFF
--- a/resources/assets/styles/content.less
+++ b/resources/assets/styles/content.less
@@ -357,6 +357,7 @@ html {
       font-size: 93%;
       padding-left: 3px;
       padding-right: 3px;
+      overflow-y: hidden;
     }
   }
 }


### PR DESCRIPTION
This will remove the y scroll bar that would appear in the cache loader container.

Before:
<img src="http://i.imgur.com/q8OYM2k.png" alt="before">
After:
<img src="http://i.imgur.com/llbshnz.png" alt="after">