### PR TITLE
Fixed genre merging

### DIFF
--- a/app/Jobs/DeleteGenre.php
+++ b/app/Jobs/DeleteGenre.php
@@ -63,14 +63,17 @@ class DeleteGenre extends Job implements ShouldQueue
 
         // This is done instead of a single UPDATE query in order to
         // generate revision logs for the change.
-        $this->genreToDelete->tracks()->each(function ($track) {
-            /** @var Track $track */
-
-            $track->genre_id = $this->destinationGenre->id;
-            $track->save();
-            $track->updateTags();
-        });
+        $tracks = Track::whereGenreId($this->genreToDelete->id)->get();
 
         $this->genreToDelete->delete();
+        $chunks = $tracks->chunk(200);
+
+        foreach ($chunks as $chunk) {
+            foreach ($chunk as $track) {
+                $track->genre_id = $this->destinationGenre->id;
+                $track->save();
+                $track->updateTags();
+            }
+        }
     }
 }


### PR DESCRIPTION
Turns out that, for some reason, tracks on the genre being deleted did not get updated after the genre was deleted. This was fixed by deleting the genre after assigning the new genre id