### PR TITLE
Null handling of soft deleted tracks for favourites page

### DIFF
--- a/app/Models/Favourite.php
+++ b/app/Models/Favourite.php
@@ -91,8 +91,11 @@ class Favourite extends Model
             } else {
                 if ($this->playlist_id) {
                     return $this->playlist;
-                } // no resource - this should never happen under real circumstances
+                }
                 else {
+                    // No resource
+                    // In this case, either the resource was
+                    // soft-deleted or something else occurred.
                     return null;
                 }
             }
@@ -101,6 +104,11 @@ class Favourite extends Model
 
     public function getTypeAttribute()
     {
-        return get_class($this->resource);
+        // As of PHP 7.2, get_class is picky about null args
+        if ($resource = $this->resource) {
+            return get_class($resource);
+        } else {
+            return null;
+        }
     }
 }

--- a/app/Models/Favourite.php
+++ b/app/Models/Favourite.php
@@ -105,10 +105,7 @@ class Favourite extends Model
     public function getTypeAttribute()
     {
         // As of PHP 7.2, get_class is picky about null args
-        if ($resource = $this->resource) {
-            return get_class($resource);
-        } else {
-            return null;
-        }
+        $resource = $this->resource;
+        return $resource ? get_class($resource) : null;
     }
 }


### PR DESCRIPTION
Soft deleted resources yield a null value in Favourite->getResourceAttribute(). As a result of this and recent PHP changes, `get_class` now throws an exception for user favorites when a soft deleted resource is present. 

This PR improves null handling in this case.